### PR TITLE
Small fix in .htaccess example

### DIFF
--- a/examples/urlrewrite/htaccess.conf
+++ b/examples/urlrewrite/htaccess.conf
@@ -2,7 +2,9 @@
   Options +FollowSymlinks
   Options +Indexes
   RewriteEngine on
-  # RewriteBase /my_app/ # if your app is in a subfolder
+
+  # if your app is in a subfolder
+  # RewriteBase /my_app/ 
 
   # test string is a valid files
   RewriteCond %{SCRIPT_FILENAME} !-f


### PR DESCRIPTION
Hi

I had to use RewriteBase today, so I uncommented the line in question in the example .htaccess file. After a bit of troubleshooting I found out that comments may not be included on a line after a configuration directive.

I've made a small fix to prevent others from stumbling into this. Would you like to include it?

Regards,
Erik
