### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "sofadesign/limonade",
+    "description": "a PHP micro-framework",
+    "homepage": "http://www.limonade-php.net/",
+    "keywords": ["microframework"],
+    "autoload": {
+        "files": ["lib/limonade.php"]
+    }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org/) is a dependency manager for PHP similar to `bundler` for Ruby and others. It makes library installation and management easier, and more importantly encourages code re-use within the PHP world, something PHP currently does VERY poorly.

If you merge this PR and then publish this git repo on http://packagist.org, then installing is a matter of adding a line to a project's `composer.json` file and then running `composer install`.

The only change is to add a `composer.json` which defines the package.
