### PR TITLE
mime_type returns null if the extension is unknown

### DIFF
--- a/lib/limonade.php
+++ b/lib/limonade.php
@@ -2412,7 +2412,12 @@ function mime_type($ext = null)
     'xyz'     => 'chemical/x-xyz',
     'zip'     => 'application/zip'
   );
-  return is_null($ext) ? $types : $types[strtolower($ext)];
+
+  if (is_null($ext)) return $types;
+
+  $lower_ext = strtolower($ext);
+
+  return isset($types[$lower_ext]) ? $types[$lower_ext] : null;
 }
 
 /**


### PR DESCRIPTION
This fixes [#41](https://github.com/sofadesign/limonade/issues/41).
