### PR TITLE
Adjust $_SERVER[CONTENT_TYPE] to ignore if the server is not setting tha...

### DIFF
--- a/lib/limonade.php
+++ b/lib/limonade.php
@@ -517,7 +517,7 @@ function env($reset = null)
     $method = request_method($env);
 
     $varname = "_$method";
-    if (strpos($_SERVER['CONTENT_TYPE'], 'application/json') === 0)
+    if ((isset($_SERVER['CONTENT_TYPE'])) && (strpos($_SERVER['CONTENT_TYPE'], 'application/json') === 0))
     {
       // handle PUT/POST requests which have JSON in request body
       $GLOBALS[$varname] = json_decode(file_get_contents('php://input'), true);


### PR DESCRIPTION
...t

Line 520 broke an existing implementation I had running because the $_SERVER['CONTENT_TYPE'] is not being set by my server.  I'm not sure if this is a wide ranging issue, but this fixed the problem for me locally.
